### PR TITLE
Standardize main menu to titlecase

### DIFF
--- a/Code/display.cpp
+++ b/Code/display.cpp
@@ -375,7 +375,7 @@ void stratego_display::display_menu() {
 		display = display + "                                                          ";
 		display = display + "  Load Game \n";
 		display = display + "                                                          ";
-		display = display + "  exit \n";
+		display = display + "  Exit \n";
 		io.print(display);
 	}
 	else if (get_menu_selection() == load_game) {
@@ -384,7 +384,7 @@ void stratego_display::display_menu() {
 		display = display + "                                                          ";
 		display = display + "* Load Game \n";
 		display = display + "                                                          ";
-		display = display + "  exit \n";
+		display = display + "  Exit \n";
 		io.print(display);
 	}
 	else if (get_menu_selection() == exit_game) {
@@ -393,7 +393,7 @@ void stratego_display::display_menu() {
 		display = display + "                                                          ";
 		display = display + "  Load Game \n";
 		display = display + "                                                          ";
-		display = display + "* exit \n";
+		display = display + "* Exit \n";
 		io.print(display);
 	}
 }


### PR DESCRIPTION
Fix 'exit' in main menu being lowercase.
Fixes #8 