### PR TITLE
Refact class into namespace stratego_io

### DIFF
--- a/Code/display.cpp
+++ b/Code/display.cpp
@@ -199,8 +199,8 @@ void stratego_display::display_pieces_out_of_play(int player1_pieces_out[12], in
 	}
 	player1_disp = player1_disp + "    \n";
 	player2_disp = player2_disp + "    \n";
-	io.print(player1_disp);
-	io.print(player2_disp);
+	stratego_io::print(player1_disp);
+	stratego_io::print(player2_disp);
 }
 
 void stratego_display::add_board_pieces_to_spaces() {
@@ -342,7 +342,7 @@ void stratego_display::display_board(stratego_piece board_pieces[80]) {
 		printable_board = printable_board + ".---.---.---.---.---.---.---.---.---.---.\n";
 	}
 
-	io.print(printable_board);
+	stratego_io::print(printable_board);
 
 	if (_display_pieces_out_of_play) {
 		int player1_pieces_out[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -376,7 +376,7 @@ void stratego_display::display_menu() {
 		display = display + "  Load Game \n";
 		display = display + "                                                          ";
 		display = display + "  Exit \n";
-		io.print(display);
+		stratego_io::print(display);
 	}
 	else if (get_menu_selection() == load_game) {
 		std::string display = "                                                          ";
@@ -385,7 +385,7 @@ void stratego_display::display_menu() {
 		display = display + "* Load Game \n";
 		display = display + "                                                          ";
 		display = display + "  Exit \n";
-		io.print(display);
+		stratego_io::print(display);
 	}
 	else if (get_menu_selection() == exit_game) {
 		std::string display = "                                                          ";
@@ -394,16 +394,16 @@ void stratego_display::display_menu() {
 		display = display + "  Load Game \n";
 		display = display + "                                                          ";
 		display = display + "* Exit \n";
-		io.print(display);
+		stratego_io::print(display);
 	}
 }
 
 void stratego_display::display_player1_preturn_menu() {
-	io.print(player1_name + "'s turn. Press space to begin.");
+	stratego_io::print(player1_name + "'s turn. Press space to begin.");
 }
 
 void stratego_display::display_player2_preturn_menu() {
-	io.print(player2_name + "'s turn. Press space to begin.");
+	stratego_io::print(player2_name + "'s turn. Press space to begin.");
 }
 
 menu_options stratego_display::get_menu_selection() {
@@ -415,43 +415,43 @@ void stratego_display::display_rules() {
 }
 
 void stratego_display::display_controls() {
-	io.print("CONTROLS:\n\n");
-	io.print("Go back   : q\n\n");
-	io.print("MOVING CURSER\n");
-	io.print("Operation : Button\n");
-	io.print("Move up   : Up arrow\n");
-	io.print("Move down : Down arrow\n");
-	io.print("Move right: Right arrow\n");
-	io.print("Move left : Left arrow\n");
-	io.print("\n");
-	io.print("GAME SETUP\n");
-	io.print("Operation : Button\n");
-	io.print("Place 1   : 1\n");
-	io.print("Place 2   : 2\n");
-	io.print("Place 3   : 3\n");
-	io.print("Place 4   : 4\n");
-	io.print("Place 5   : 5\n");
-	io.print("Place 6   : 6\n");
-	io.print("Place 7   : 7\n");
-	io.print("Place 8   : 8\n");
-	io.print("Place 9   : 9\n");
-	io.print("Place s   : s\n");
-	io.print("Place b   : b\n");
-	io.print("Place f   : f\n");
-	io.print("If you want to remove a piece from the board, place another piece on top of it.\nThis will replace the piece on the board with the new piece.\n");
-	io.print("\n");
-	io.print("GAME PLAY PIECE MANIPULATION\n");
-	io.print("Operation : Button\n");
-	io.print("Select    : Enter\n");
-	io.print("Unselect  : q\n");
-	io.print("Move up   : Up arrow\n");
-	io.print("Move down : Down arrow\n");
-	io.print("Move right: Right arrow\n");
-	io.print("Move left : Left arrow\n");
-	io.print("Finalize  : Enter\n");
-	io.print("Save      : S\n");
-	io.print("Note that you can only save the game at a preturn menu.\n\n");
-	io.print("To delete a game, you can press d while the game is selected\n in the load menu.");
+	stratego_io::print("CONTROLS:\n\n");
+	stratego_io::print("Go back   : q\n\n");
+	stratego_io::print("MOVING CURSER\n");
+	stratego_io::print("Operation : Button\n");
+	stratego_io::print("Move up   : Up arrow\n");
+	stratego_io::print("Move down : Down arrow\n");
+	stratego_io::print("Move right: Right arrow\n");
+	stratego_io::print("Move left : Left arrow\n");
+	stratego_io::print("\n");
+	stratego_io::print("GAME SETUP\n");
+	stratego_io::print("Operation : Button\n");
+	stratego_io::print("Place 1   : 1\n");
+	stratego_io::print("Place 2   : 2\n");
+	stratego_io::print("Place 3   : 3\n");
+	stratego_io::print("Place 4   : 4\n");
+	stratego_io::print("Place 5   : 5\n");
+	stratego_io::print("Place 6   : 6\n");
+	stratego_io::print("Place 7   : 7\n");
+	stratego_io::print("Place 8   : 8\n");
+	stratego_io::print("Place 9   : 9\n");
+	stratego_io::print("Place s   : s\n");
+	stratego_io::print("Place b   : b\n");
+	stratego_io::print("Place f   : f\n");
+	stratego_io::print("If you want to remove a piece from the board, place another piece on top of it.\nThis will replace the piece on the board with the new piece.\n");
+	stratego_io::print("\n");
+	stratego_io::print("GAME PLAY PIECE MANIPULATION\n");
+	stratego_io::print("Operation : Button\n");
+	stratego_io::print("Select    : Enter\n");
+	stratego_io::print("Unselect  : q\n");
+	stratego_io::print("Move up   : Up arrow\n");
+	stratego_io::print("Move down : Down arrow\n");
+	stratego_io::print("Move right: Right arrow\n");
+	stratego_io::print("Move left : Left arrow\n");
+	stratego_io::print("Finalize  : Enter\n");
+	stratego_io::print("Save      : S\n");
+	stratego_io::print("Note that you can only save the game at a preturn menu.\n\n");
+	stratego_io::print("To delete a game, you can press d while the game is selected\n in the load menu.");
 }
 
 void stratego_display::set_player1_name(std::string name) {
@@ -609,7 +609,7 @@ void stratego_display::save_move(int player, stratego_piece losing_piece) {
 }
 
 void stratego_display::display_saved_move() {
-	io.print(screen_shot);
+	stratego_io::print(screen_shot);
 }
 
 void stratego_display::invert_arrows() {
@@ -676,7 +676,7 @@ void stratego_display::display_load_game_menu(std::vector<std::string> saved_gam
 			saved_game_list = saved_game_list + "  " + saved_game_names[saved_game] + "\n";
 		}
 	}
-	io.print(saved_game_list);
+	stratego_io::print(saved_game_list);
 }
 
 std::string stratego_display::get_screen_shot() {
@@ -696,7 +696,7 @@ std::string stratego_display::get_player2_name() {
 }
 
 void stratego_display::display_logo() {
-	io.print(R"(_____/\\\\\\\\\\\______________________________________________________________________________________________________)"
+	stratego_io::print(R"(_____/\\\\\\\\\\\______________________________________________________________________________________________________)"
 	        "\n"
 	        R"( ___/\\\/////////\\\____________________________________________________________________________________________________  )"
 	        "\n"
@@ -721,6 +721,5 @@ void stratego_display::add_hint() {
 }
 
 void stratego_display::execute_add_hint() {
-	stratego_io io;
-	io.print("Press Enter.\n");
+	stratego_io::print("Press Enter.\n");
 }

--- a/Code/display.h
+++ b/Code/display.h
@@ -13,7 +13,6 @@ enum menu_options {
 
 class stratego_display {
 private:
-	stratego_io io;
 	// data on game pieces
 	stratego_piece _board_pieces[80];
 

--- a/Code/file_managment.cpp
+++ b/Code/file_managment.cpp
@@ -14,7 +14,6 @@
 #include <sys/types.h>
 
 void stratego_file_managment::save_game(std::string file_name, stratego_piece board_info[80], int player_turn, std::string saved_move_shot, std::string player1_name, std::string player2_name) {
-	stratego_io io;
 	std::string content = "";
 	content = content + player1_name + "\n";
 	content = content + player2_name + "\n";
@@ -43,18 +42,17 @@ void stratego_file_managment::save_game(std::string file_name, stratego_piece bo
 	content = content + "#\n";
 	content = content + saved_move_shot;
 	if (write_file(file_name, content)) {
-		io.print(file_name + " saved!\n");
+		stratego_io::print(file_name + " saved!\n");
 	}
 	else {
-		io.print("Failed to save game.");
+		stratego_io::print("Failed to save game.");
 	}
 }
 
 void stratego_file_managment::load_game(std::string file_name, stratego_piece(&board_info)[80], int& player_turn, std::string& saved_move_shot, std::string& player1_name, std::string& player2_name) {
-	stratego_io io;
 	std::string content = read_file(file_name);
 	if (content == "") {
-		io.print("Could not open the file.\n");
+		stratego_io::print("Could not open the file.\n");
 	}
 	else {
 		int position = 0;
@@ -124,7 +122,6 @@ bool stratego_file_managment::write_file(std::string file_name, std::string cont
 }
 
 std::string stratego_file_managment::read_file(std::string file_name) {
-	stratego_io io;
 	std::ifstream file(_working_directory + file_name);
 	std::string content;
 
@@ -138,7 +135,7 @@ std::string stratego_file_managment::read_file(std::string file_name) {
 		file.close();
 	}
 	else {
-		io.print("Cannot find file.\n");
+		stratego_io::print("Cannot find file.\n");
 		content = "";
 	}
 	return content;

--- a/Code/game_operations.cpp
+++ b/Code/game_operations.cpp
@@ -21,9 +21,9 @@ void stratego_game_operations::menu() {
     int position = 0;
     display.set_menu_selection(new_game);
     do {
-        io.clear();
+        stratego_io::clear();
         display.display_menu();
-        input = io.getchar();
+        input = stratego_io::getchar();
         if ((input == UP) && (position > 0)) {
             position--;
         }
@@ -48,21 +48,21 @@ void stratego_game_operations::setup() {
     logic.reset_board();
     logic.set_game_state(placing_pieces);
 
-    io.clear();
-    io.print("Enter your name player 1:\n");
+    stratego_io::clear();
+    stratego_io::print("Enter your name player 1:\n");
     std::string player_name = "";
-    player_name = io.getline();
+    player_name = stratego_io::getline();
     display.set_player1_name(player_name);
 
-    io.clear();
-    io.print("Enter your name player 2:\n");
-    player_name = io.getline();
+    stratego_io::clear();
+    stratego_io::print("Enter your name player 2:\n");
+    player_name = stratego_io::getline();
     display.set_player2_name(player_name);
 
     do {
-        io.clear();
+        stratego_io::clear();
         display.display_player1_preturn_menu();
-        input = io.getchar();
+        input = stratego_io::getchar();
         if (input == H) {
             help_menu();
         }
@@ -78,9 +78,9 @@ void stratego_game_operations::setup() {
         display.add_standard_curser(logic.get_curser_row(), logic.get_curser_column());
         stratego_piece board_info[80];
         logic.get_board_info(board_info);
-        io.reset();
+        stratego_io::reset();
         display.display_board(board_info);
-        input = io.getchar();
+        input = stratego_io::getchar();
         if ((input == UP) || (input == DOWN) || (input == RIGHT) || (input == LEFT)) {
             logic.move_curser(interface.user_to_logic(input));
         }
@@ -95,9 +95,9 @@ void stratego_game_operations::setup() {
     } while (!logic.player1_pieces_placed());
 
     do {
-        io.clear();
+        stratego_io::clear();
         display.display_player2_preturn_menu();
-        input = io.getchar();
+        input = stratego_io::getchar();
         if (input == H) {
             help_menu();
         }
@@ -114,9 +114,9 @@ void stratego_game_operations::setup() {
         display.add_standard_curser(logic.get_curser_row(), logic.get_curser_column());
         stratego_piece board_info[80];
         logic.get_board_info(board_info);
-        io.reset();
+        stratego_io::reset();
         display.display_board(board_info);
-        input = io.getchar();
+        input = stratego_io::getchar();
         if ((input == UP) || (input == DOWN) || (input == RIGHT) || (input == LEFT)) {
             logic.move_curser(interface.user_to_logic(input));
         }
@@ -137,13 +137,13 @@ void stratego_game_operations::load() {
     std::vector<std::string> saved_game_names;
     file_managment.get_saved_game_names(saved_game_names);
     int saved_game_selection = 0;
-    io.clear();
+    stratego_io::clear();
     do {
-        io.reset();
+        stratego_io::reset();
         if (saved_game_names.size() != 0) {
             display.display_load_game_menu(saved_game_names, saved_game_selection);
         }
-        input = io.getchar();
+        input = stratego_io::getchar();
         if ((input == UP) && (saved_game_selection > 0)) {
             saved_game_selection--;
         }
@@ -173,7 +173,7 @@ void stratego_game_operations::load() {
         else if (input == D) {
             file_managment.delete_file(saved_game_names[saved_game_selection]);
             file_managment.get_saved_game_names(saved_game_names);
-            io.clear();
+            stratego_io::clear();
         }
 
         if (input == H) {
@@ -203,10 +203,10 @@ void stratego_game_operations::game_loop() {
             display.hide_player1();
         }
         display.add_pieces_out_of_play();
-        io.reset();
+        stratego_io::reset();
         display.display_board(board_info);
 
-        input = io.getchar();
+        input = stratego_io::getchar();
         if (logic.get_game_state() == moving_curser) {
             moving_curser_handle(input);
         }
@@ -225,17 +225,17 @@ void stratego_game_operations::game_loop() {
     } while (!logic.player1_won() && !logic.player2_won());
     
     if (logic.player1_won()) {
-        io.clear();
-        io.print(display.get_player1_name() + " won!");
+        stratego_io::clear();
+        stratego_io::print(display.get_player1_name() + " won!");
         do {
-            input = io.getchar();
+            input = stratego_io::getchar();
         } while (input != ENTER);
     }
     else if (logic.player2_won()) {
-        io.clear();
-        io.print(display.get_player2_name() + " won!");
+        stratego_io::clear();
+        stratego_io::print(display.get_player2_name() + " won!");
         do {
-            input = io.getchar();
+            input = stratego_io::getchar();
         } while (input != ENTER);
     }
 }
@@ -256,22 +256,22 @@ void stratego_game_operations::end_game() {
         display.hide_player2();
         display.orient_for_player(1);
         display.add_pieces_out_of_play();
-        io.clear();
-        io.print(display.get_player1_name() + "'s pieces:\n");
+        stratego_io::clear();
+        stratego_io::print(display.get_player1_name() + "'s pieces:\n");
         display.display_board(board_info);
         int input = -1;
         do {
-            input = io.getchar();
+            input = stratego_io::getchar();
         } while (input != ENTER);
 
         display.hide_player1();
         display.orient_for_player(2);
         display.add_pieces_out_of_play();
-        io.clear();
-        io.print(display.get_player2_name() + "'s pieces:\n");
+        stratego_io::clear();
+        stratego_io::print(display.get_player2_name() + "'s pieces:\n");
         display.display_board(board_info);
         do {
-            input = io.getchar();
+            input = stratego_io::getchar();
         } while (input != ENTER);
     }
 }
@@ -279,12 +279,12 @@ void stratego_game_operations::end_game() {
 void stratego_game_operations::help_menu() {
     int input = -1;
    
-    io.clear();
+    stratego_io::clear();
     display.display_controls();
     do {
-        input = io.getchar();
+        input = stratego_io::getchar();
     } while (input != Q);
-    io.clear();
+    stratego_io::clear();
 }
 
 bool stratego_game_operations::turn_ended_handle() {
@@ -293,9 +293,9 @@ bool stratego_game_operations::turn_ended_handle() {
         logic.set_curser_row(2);
         logic.set_curser_column(4);
         do {
-            io.clear();
+            stratego_io::clear();
             display.display_player2_preturn_menu();
-            input = io.getchar();
+            input = stratego_io::getchar();
             if (input == H) {
                 help_menu();
             }
@@ -306,11 +306,11 @@ bool stratego_game_operations::turn_ended_handle() {
         }
         logic.set_turn(2);
         if (!display.screen_shot_empty()) {
-            io.reset();
+            stratego_io::reset();
             display.display_saved_move();
-            io.print(display.get_player1_name() + "'s move. Press enter to continue.");
+            stratego_io::print(display.get_player1_name() + "'s move. Press enter to continue.");
             do {
-                input = io.getchar();
+                input = stratego_io::getchar();
             } while (input != ENTER);
         }
         display.add_standard_curser(logic.get_curser_row(), logic.get_curser_column());
@@ -319,9 +319,9 @@ bool stratego_game_operations::turn_ended_handle() {
         logic.set_curser_row(7);
         logic.set_curser_column(5);
         do {
-            io.clear();
+            stratego_io::clear();
             display.display_player1_preturn_menu();
-            input = io.getchar();
+            input = stratego_io::getchar();
             if (input == H) {
                 help_menu();
             }
@@ -332,11 +332,11 @@ bool stratego_game_operations::turn_ended_handle() {
         }
         logic.set_turn(1);
         if (!display.screen_shot_empty()) {
-            io.reset();
+            stratego_io::reset();
             display.display_saved_move();
-            io.print(display.get_player2_name() + "'s move. Press enter to continue.");
+            stratego_io::print(display.get_player2_name() + "'s move. Press enter to continue.");
             do {
-                input = io.getchar();
+                input = stratego_io::getchar();
             } while (input != ENTER);
         }
         display.add_standard_curser(logic.get_curser_row(), logic.get_curser_column());
@@ -462,13 +462,13 @@ void stratego_game_operations::battling_handle(int input) {
 }
 
 void stratego_game_operations::save_game_handle() {
-    io.clear();
-    io.print("Enter a name:\n");
+    stratego_io::clear();
+    stratego_io::print("Enter a name:\n");
     std::string game_name = "";
     do {
-        game_name = io.getline();
+        game_name = stratego_io::getline();
         if (file_managment.duplicate_name(game_name)) {
-            io.print("Game already exists. Enter a different name:\n");
+            stratego_io::print("Game already exists. Enter a different name:\n");
         }
     } while (file_managment.duplicate_name(game_name));
     stratego_piece board_info[80];

--- a/Code/game_operations.h
+++ b/Code/game_operations.h
@@ -10,7 +10,6 @@ class stratego_game_operations {
 private:
 	bool game_loaded;
 	stratego_display display;
-	stratego_io io;
 	stratego_logic logic;
 	stratego_interface interface;
 	stratego_file_managment file_managment;

--- a/Code/io.cpp
+++ b/Code/io.cpp
@@ -8,7 +8,7 @@
 #include <ncurses.h>
 #endif
 
-void stratego_io::print(std::string output) {
+void stratego_io::print(const std::string& output) {
 	#ifdef _WIN32
 		std::cout << output;
 	#elif __linux__

--- a/Code/io.h
+++ b/Code/io.h
@@ -1,13 +1,12 @@
 #pragma once
 #include <string>
 
-class stratego_io {
-private:
 
-public:
-	void print(std::string output);
-	int getchar();
-	void clear();
-	void reset();
-	std::string getline();
+namespace stratego_io
+{
+   void print(const std::string& output);
+   int getchar();
+   void clear();
+   void reset();
+   std::string getline();
 };

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DEPS := $(OCJS:.o=.d)
 
 LDFLAGS := -lncurses
 INC_FLAGS := $(addprefix -I,$(INC_DIR))
-CXXFLAGS := -std=c++17 $(LDFLAGS) -O2 $(INC_FLAGS) -Wall
+CXXFLAGS := -std=c++17 $(LDFLAGS) -O2 $(INC_FLAGS) -Wall -MMD -MP
 
 .PHONY: all clean
 
@@ -27,7 +27,7 @@ $(BLD_DIR)/%.cpp.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	rm -r $(BLD_DIR)
-	rm $(EXECUTABLE)
+	-rm -r $(BLD_DIR)
+	-rm $(EXECUTABLE)
 
 -include $(DEPS)


### PR DESCRIPTION
I noticed that the class stratego_io defined in io.h does not need to be a class since it does not store variables; This means it can be turned into a namespace. I experimented with making the functions static instead of namespace but ncurses broke.

**NOTICE: testing on windows will be necessary to make sure nothing breaks; this is a huge change.**